### PR TITLE
[CCP-145] Overflow issue fixed in synonym modal

### DIFF
--- a/Conceptpower+Spring/src/main/webapp/WEB-INF/views/auth/concepts/ConceptAddView.jsp
+++ b/Conceptpower+Spring/src/main/webapp/WEB-INF/views/auth/concepts/ConceptAddView.jsp
@@ -543,7 +543,7 @@
 						</div>
 
 
-						<div class="modal-body">
+						<div class="modal-body synonym-modal-body">
 							<div id="synonymViewDiv"
 								style="max-width: 1000px; max-height: 500px;" hidden="true">
 

--- a/Conceptpower+Spring/src/main/webapp/WEB-INF/views/auth/concepts/ConceptEditView.jsp
+++ b/Conceptpower+Spring/src/main/webapp/WEB-INF/views/auth/concepts/ConceptEditView.jsp
@@ -331,7 +331,7 @@ $(function() {
 						</div>
 
 
-						<div class="modal-body">
+						<div class="modal-body synonym-modal-body">
 							<div id="synonymViewDiv"
 								style="max-width: 1000px; max-height: 500px;" hidden="true">
 

--- a/Conceptpower+Spring/src/main/webapp/WEB-INF/views/auth/concepts/ConceptWrapperAddView.jsp
+++ b/Conceptpower+Spring/src/main/webapp/WEB-INF/views/auth/concepts/ConceptWrapperAddView.jsp
@@ -473,7 +473,7 @@
                         </div>
 
 
-                        <div class="modal-body">
+                        <div class="modal-body synonym-modal-body">
                             <div id="synonymViewDiv"
                                 style="max-width: 1000px; max-height: 500px;"
                                 hidden="true">

--- a/Conceptpower+Spring/src/main/webapp/resources/assets/css/main.css
+++ b/Conceptpower+Spring/src/main/webapp/resources/assets/css/main.css
@@ -122,4 +122,8 @@ div.scrollable {
     overflow: auto;
     word-wrap: break-word;
 }
-		
+
+.synonym-modal-body {
+    overflow-y: auto;
+    max-height: 250px;
+}


### PR DESCRIPTION
Synonym modal was overflowing when synonym
is searched in the modal. Fixed it by adding an
overflow auto and setting  a max-height