### PR TITLE
[CCP-169] Added encoding for characters for all responses

### DIFF
--- a/Conceptpower+Spring/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
+++ b/Conceptpower+Spring/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
@@ -15,7 +15,13 @@
 		infrastructure -->
 
 	<!-- Enables the Spring MVC @Controller programming model -->
-	<mvc:annotation-driven />
+	<mvc:annotation-driven>
+        <mvc:message-converters register-defaults="true">
+            <bean class="org.springframework.http.converter.StringHttpMessageConverter">
+                <constructor-arg index="0" name="defaultCharset" value="UTF-8"/>
+            </bean>
+        </mvc:message-converters>    
+    </mvc:annotation-driven>
 
 	<!-- Handles HTTP GET requests for /resources/** by efficiently serving 
 		up static resources in the ${webappRoot}/resources directory -->


### PR DESCRIPTION
Spring by default uses ISO-8859-1 so characters were appearing
as ?? in UI. In UI we are using UTF-8. Added message converters
to make sure characters are encoded in UTF-8 format.