### PR TITLE
[CCP-170] Description will not be escaped anymore

### DIFF
--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/servlet/wrapper/impl/ConceptEntryWrapperCreator.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/servlet/wrapper/impl/ConceptEntryWrapperCreator.java
@@ -82,9 +82,11 @@ public class ConceptEntryWrapperCreator implements IConceptWrapperCreator {
 
             // build description considering all the wordnet entries wrappe
             StringBuffer sb = new StringBuffer();
+            sb.append(entry.getDescription());
             if (wordnetEntries.size() > 0) {
                 for (ConceptEntry wordnetConcept : wordnetEntries) {
-                    if (wordnetConcept.getDescription() != null) {
+                    if (wordnetConcept.getDescription() != null && (entry.getDescription() == null
+                            || !wordnetConcept.getDescription().trim().equals(entry.getDescription().trim()))) {
                         sb.append("<br/><i>" + wordnetConcept.getWord() + "</i>");
                         sb.append("<br/>" + wordnetConcept.getDescription());
                     }

--- a/Conceptpower+Spring/src/main/webapp/WEB-INF/views/home.jsp
+++ b/Conceptpower+Spring/src/main/webapp/WEB-INF/views/home.jsp
@@ -228,7 +228,7 @@ function showFormProcessing() {
                 value="${concept.entry.conceptList}"></c:out></font></td>
           <td align="justify">
                 <div class="scrollable" style="max-height: 100px; max-width: 400px;">
-                    <c:out value="${concept.description}"></c:out>
+                    <c:out value="${concept.description}" escapeXml="false"></c:out>
                 </div>
           </td>
           <td align="justify"><font size="2"><c:out


### PR DESCRIPTION
Description was not appearing properly in UI. HTML tags
were escaped and rendered as normal string. From now on
all html tags will be rendered properly for description alone.