### PR TITLE
[CCP-193] Rest call search fix

### DIFF
--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/lucene/impl/LuceneUtility.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/lucene/impl/LuceneUtility.java
@@ -52,6 +52,7 @@ import edu.asu.conceptpower.app.wordnet.Constants;
 import edu.asu.conceptpower.app.wordnet.WordNetConfiguration;
 import edu.asu.conceptpower.core.ConceptEntry;
 import edu.asu.conceptpower.core.IndexingEvent;
+import edu.asu.conceptpower.rest.SearchParamters;
 import edu.mit.jwi.Dictionary;
 import edu.mit.jwi.IDictionary;
 import edu.mit.jwi.item.IIndexWord;
@@ -394,7 +395,7 @@ public class LuceneUtility implements ILuceneUtility {
             int numberOfRecordsPerPage) throws LuceneException, IllegalAccessException {
 
         if (operator == null) {
-            operator = "AND";
+            operator = SearchParamters.OP_AND;
         }
 
         StringBuffer queryString = new StringBuffer();

--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/ConceptSearch.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/ConceptSearch.java
@@ -97,18 +97,20 @@ public class ConceptSearch {
         }
 
         Map<String, String> searchFields = new HashMap<String, String>();
-        String operator = SearchParamters.OP_OR;
+        String operator = SearchParamters.OP_AND;
         int page = 1;
 
         for (Field field : conceptSearchParameters.getClass().getDeclaredFields()) {
             field.setAccessible(true);
             if (field.getName().equalsIgnoreCase("type_uri")) {
-                searchFields.put("type_id",
-                        uriHelper.getTypeId(String.valueOf(field.get(conceptSearchParameters))));
+                if (field.get(conceptSearchParameters) != null) {
+                    searchFields.put("type_id",
+                            uriHelper.getTypeId(String.valueOf(field.get(conceptSearchParameters))));
+                }
             } else if (SearchParamters.OPERATOR.equalsIgnoreCase(field.getName())) {
                 // If the value is null, then operator will be OR by default
                 if (field.get(conceptSearchParameters) != null) {
-                    operator = String.valueOf(field.get(conceptSearchParameters));
+                    operator = String.valueOf(field.get(conceptSearchParameters)).toUpperCase();
                 }
             } else if (SearchParamters.PAGE.equalsIgnoreCase(field.getName())) {
                 page = field.get(conceptSearchParameters) != null

--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/ConceptSearch.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/ConceptSearch.java
@@ -3,6 +3,7 @@ package edu.asu.conceptpower.rest;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -146,7 +147,7 @@ public class ConceptSearch {
             return new ResponseEntity<String>(msg.getXML(xmlEntries), HttpStatus.OK);
         }
         
-        Map<ConceptEntry, ConceptType> entryMap = new HashMap<ConceptEntry, ConceptType>();
+        Map<ConceptEntry, ConceptType> entryMap = new LinkedHashMap<ConceptEntry, ConceptType>();
 
         XMLConceptMessage msg = messageFactory.createXMLConceptMessage();
         for (ConceptEntry entry : searchResults) {

--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/SearchParamters.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/SearchParamters.java
@@ -2,7 +2,7 @@ package edu.asu.conceptpower.rest;
 
 public interface SearchParamters {
 
-	public final static String OPERATOR = "operator";
+    public final static String OPERATOR = "operator";
     public final static String OP_AND = "AND";
     public final static String OP_OR = "OR";
     public final static String PAGE = "page";

--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/SearchParamters.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/SearchParamters.java
@@ -3,8 +3,8 @@ package edu.asu.conceptpower.rest;
 public interface SearchParamters {
 
 	public final static String OPERATOR = "operator";
-	public final static String OP_AND = "and";
-	public final static String OP_OR = "or";
+    public final static String OP_AND = "AND";
+    public final static String OP_OR = "OR";
     public final static String PAGE = "page";
     public final static String NUMBER_OF_RECORDS_PER_PAGE = "number_of_records_per_page";
 }

--- a/Conceptpower+Spring/src/main/webapp/WEB-INF/views/home.jsp
+++ b/Conceptpower+Spring/src/main/webapp/WEB-INF/views/home.jsp
@@ -13,6 +13,7 @@ $(document).ready(function() {
 		"bJQueryUI" : true,
 		"sPaginationType" : "full_numbers",
 		"bAutoWidth" : false,
+		"aaSorting" : [],
 		"aoColumnDefs" : [ 
 				<sec:authorize access="isAuthenticated()">
 			    {
@@ -42,14 +43,7 @@ $(document).ready(function() {
   			    	}
   			    }
   				</sec:authorize>
-		],
-				
-		<sec:authorize access="isAuthenticated()">
-			"order": [[ 2, "desc" ]]
-		</sec:authorize>
-		<sec:authorize access="not isAuthenticated()">
-			"order": [[ 0, "desc" ]]
-		</sec:authorize>
+		]
 	});
 	$('#viafSearchResult').dataTable({
 		"bJQueryUI" : true,


### PR DESCRIPTION
There were two issues in rest ful call concept search
1) The type_id has been included in the query even when
type_id is null. When type_id is null, the old code used a
String.valueOf so "null" string was included in query string.
This is now removed checking null for types field like all other
fields.

2) The default search operator was OR for concept search rest
call, where as the search for UI is AND. Made sure both the search
use AND for default operator. If operator is supplied by user, then
that operator will be overridden.

3) There was one more issue with operator. The operators supplied
to lucene query string should always be in upper case. So made changes
accordingly.