### PR TITLE
[CCP-189] Changed the search field name of equals_to

### DIFF
--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/constants/SearchFieldNames.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/constants/SearchFieldNames.java
@@ -2,7 +2,7 @@ package edu.asu.conceptpower.app.constants;
 
 public interface SearchFieldNames {
 
-	public final static String EQUALS_TO = "equals_to";
+    public final static String EQUAL_TO = "equal_to";
 	public final static String SIMILAR_TO = "similar_to";
 	public final static String DESCRIPTION = "description";
 	public final static String WORD = "word";

--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/constants/SearchFieldNames.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/constants/SearchFieldNames.java
@@ -3,18 +3,18 @@ package edu.asu.conceptpower.app.constants;
 public interface SearchFieldNames {
 
     public final static String EQUAL_TO = "equal_to";
-	public final static String SIMILAR_TO = "similar_to";
-	public final static String DESCRIPTION = "description";
-	public final static String WORD = "word";
-	public final static String POS = "pos";
-	public final static String CONCEPT_LIST = "concept_list";
-	public final static String TYPE_ID = "type_id";
-	public final static String CREATOR = "creator";
-	public final static String MODIFIED = "modified_by";
-	public final static String WORDNETID = "wordnetid";
-	public final static String ID = "id";
-	public final static String ISCHECKED = "isChecked";
-	public final static String TYPE_URI = "type_uri";
-	public final static String SYNONYM_ID = "synonymId";
+    public final static String SIMILAR_TO = "similar_to";
+    public final static String DESCRIPTION = "description";
+    public final static String WORD = "word";
+    public final static String POS = "pos";
+    public final static String CONCEPT_LIST = "concept_list";
+    public final static String TYPE_ID = "type_id";
+    public final static String CREATOR = "creator";
+    public final static String MODIFIED = "modified_by";
+    public final static String WORDNETID = "wordnetid";
+    public final static String ID = "id";
+    public final static String ISCHECKED = "isChecked";
+    public final static String TYPE_URI = "type_uri";
+    public final static String SYNONYM_ID = "synonymId";
     public final static String PAGE = "page";
 }

--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/core/ConceptEntry.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/core/ConceptEntry.java
@@ -56,7 +56,7 @@ public class ConceptEntry implements Serializable {
     @LuceneField(lucenefieldName = LuceneFieldNames.TYPE_ID, isTokenized = false, isMultiple = false)
     private String typeId;
 
-    @SearchField(fieldName = SearchFieldNames.EQUALS_TO)
+    @SearchField(fieldName = SearchFieldNames.EQUAL_TO)
     @LuceneField(lucenefieldName = LuceneFieldNames.EQUALS_TO, isTokenized = false, isMultiple = true)
     private String equalTo;
 

--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/ConceptSearchParameters.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/ConceptSearchParameters.java
@@ -5,7 +5,7 @@ public class ConceptSearchParameters {
     private String type_uri;
     private String operator;
     private Integer page;
-    private String equals_to;
+    private String equal_to;
     private String similar_to;
     private String description;
     private String word;
@@ -40,14 +40,6 @@ public class ConceptSearchParameters {
         if (page != null) {
             this.page = page;
         }
-    }
-
-    public String getEquals_to() {
-        return equals_to;
-    }
-
-    public void setEquals_to(String equals_to) {
-        this.equals_to = equals_to;
     }
 
     public String getSimilar_to() {
@@ -122,5 +114,13 @@ public class ConceptSearchParameters {
         if (number_of_records_per_page != null) {
             this.number_of_records_per_page = number_of_records_per_page;
         }
+    }
+
+    public String getEqual_to() {
+        return equal_to;
+    }
+
+    public void setEqual_to(String equal_to) {
+        this.equal_to = equal_to;
     }
 }

--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/Concepts.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/Concepts.java
@@ -60,13 +60,13 @@ public class Concepts {
      * Sample input for creating a concept wrapper:
      * 
      * { 
-     *     "wordnetIds": "WID-00450866-N-01-pony-trekking,WID-03981924-N-01-pony_cart",
-     *     "synonymids" : "WID-02380464-N-01-polo_pony,WID-04206225-N-03-pony",
-     *     "conceptlist" : "FirstList-1", 
-     *     "type" :"88bea1dc-1443-4296-8315-715c71128b01", 
-     *     "description" : "Description",
-     *     "equalsTo" : "equals", 
-     *     "similarTo" : "similar" 
+     *      "wordnetIds":
+     *      "WID-00450866-N-01-pony-trekking,WID-03981924-N-01-pony_cart",
+     *      "synonymids" : "WID-02380464-N-01-polo_pony,WID-04206225-N-03-pony",
+     *      "conceptlist" : "FirstList-1", 
+     *      "type" : "88bea1dc-1443-4296-8315-715c71128b01", 
+     *      "description" : "Description",
+     *      "equal_to" : "equals", "similarTo" : "similar" 
      * }
      * 
      * Please note any word or pos passed during concept wrapper creation will
@@ -77,11 +77,11 @@ public class Concepts {
      * Sample input for creating a concept:
      * 
      * { 
-     *    "word": "kitty", 
-     *    "pos": "noun",
-     *    "conceptlist": "mylist", 
-     *    "description": "Soft kitty, sleepy kitty, little ball of fur.",
-     *    "type": "3b755111-545a-4c1c-929c-a2c0d4c3913b" 
+     *      "word": "kitty", 
+     *      "pos": "noun", 
+     *      "conceptlist": "mylist", 
+     *      "description": "Soft kitty, sleepy kitty, little ball of fur.", 
+     *      "type": "3b755111-545a-4c1c-929c-a2c0d4c3913b" 
      * }
      * 
      * @param body

--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/Concepts.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/Concepts.java
@@ -66,7 +66,8 @@ public class Concepts {
      *      "conceptlist" : "FirstList-1", 
      *      "type" : "88bea1dc-1443-4296-8315-715c71128b01", 
      *      "description" : "Description",
-     *      "equal_to" : "equals", "similarTo" : "similar" 
+     *      "equal_to" : "http://viaf.org/viaf/38882290", 
+     *      "similarTo" : "http://viaf.org/viaf/43723621" 
      * }
      * 
      * Please note any word or pos passed during concept wrapper creation will

--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/JsonFields.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/JsonFields.java
@@ -15,7 +15,7 @@ public interface JsonFields {
     public final static String CONCEPT_LIST = "conceptlist";
     public final static String POS = "pos";
     public final static String DESCRIPTION = "description";
-    public final static String EQUALS = "equals";
+    public final static String EQUALS = "equal_to";
     public final static String SIMILAR = "similar";
     public final static String TYPE = "type";
     public final static String URI = "uri";


### PR DESCRIPTION
From now on concept search can be done by the predicate equal_to.
Previously the system was using the search term as equals_to but the output
was displaying as equal_to.