### PR TITLE
[CCP-218] [CCP-217]Changes for displaying merged ids and merged concepts.

### DIFF
--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/core/impl/ConceptManager.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/core/impl/ConceptManager.java
@@ -69,6 +69,14 @@ public class ConceptManager implements IConceptManager {
      */
     @Override
     public ConceptEntry getConceptEntry(String id) {
+
+        ConceptEntry[] entries = client.getEntriesByFieldContains(SearchFieldNames.MERGED_IDS, id);
+        if (entries != null && entries.length > 0) {
+            fillConceptEntry(entries[0]);
+            alternativeIdService.addAlternativeIds(id, entries[0]);
+            return entries[0];
+        }
+
         ConceptEntry entry = client.getEntry(id);
         if (entry != null) {
             fillConceptEntry(entry);

--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/msg/json/ConceptEntryMessage.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/msg/json/ConceptEntryMessage.java
@@ -51,6 +51,9 @@ public class ConceptEntryMessage {
     @JsonProperty("alternativeIds")
     private List<AlternativeId> alternativeIds;
 
+    @JsonProperty("mergedIds")
+    private List<MergedId> mergedIds;
+
     public String getId() {
         return id;
     }
@@ -169,6 +172,14 @@ public class ConceptEntryMessage {
 
     public void setConceptUri(String conceptUri) {
         this.conceptUri = conceptUri;
+    }
+
+    public List<MergedId> getMergedIds() {
+        return mergedIds;
+    }
+
+    public void setMergedIds(List<MergedId> mergedIds) {
+        this.mergedIds = mergedIds;
     }
 
 }

--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/msg/json/JsonConceptMessage.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/msg/json/JsonConceptMessage.java
@@ -1,7 +1,9 @@
 package edu.asu.conceptpower.rest.msg.json;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -82,6 +84,21 @@ public class JsonConceptMessage implements IConceptMessage {
                     alternativeIds.add(alternativeId);
                 }
                 json.setAlternativeIds(alternativeIds);
+            }
+        }
+
+        if (entry.getMergedIds() != null && !entry.getMergedIds().isEmpty()) {
+            Map<String, String> uriMap = uriCreator
+                    .getUrisBasedOnIds(new HashSet<String>(Arrays.asList(entry.getMergedIds())));
+            if (uriMap != null && !uriMap.isEmpty()) {
+                List<MergedId> mergedIds = new ArrayList<>();
+                for (Map.Entry<String, String> uri : uriMap.entrySet()) {
+                    MergedId mergedId = new MergedId();
+                    mergedId.setConceptId(uri.getKey());
+                    mergedId.setConceptUri(uri.getValue());
+                    mergedIds.add(mergedId);
+                }
+                json.setMergedIds(mergedIds);
             }
         }
         return json;

--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/msg/json/MergedId.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/msg/json/MergedId.java
@@ -1,0 +1,31 @@
+package edu.asu.conceptpower.rest.msg.json;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(Include.NON_NULL)
+public class MergedId {
+
+    @JsonProperty("concept_id")
+    private String conceptId;
+    @JsonProperty("concept_uri")
+    private String conceptUri;
+
+    public String getConceptId() {
+        return conceptId;
+    }
+
+    public void setConceptId(String conceptId) {
+        this.conceptId = conceptId;
+    }
+
+    public String getConceptUri() {
+        return conceptUri;
+    }
+
+    public void setConceptUri(String conceptUri) {
+        this.conceptUri = conceptUri;
+    }
+
+}

--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/msg/xml/XMLConceptMessage.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/msg/xml/XMLConceptMessage.java
@@ -1,6 +1,8 @@
 package edu.asu.conceptpower.rest.msg.xml;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -163,6 +165,24 @@ public class XMLConceptMessage implements IConceptMessage {
                 sb.append("</" + XMLConstants.NAMESPACE_PREFIX + ":" + XMLConstants.ALTERNATIVE_IDS + ">");
             }
 
+        }
+
+        // Adding merged ids and their corresponding uris.
+        if (entry.getMergedIds() != null && !entry.getMergedIds().isEmpty()) {
+            sb.append("<" + XMLConstants.NAMESPACE_PREFIX + ":" + XMLConstants.MERGED_IDS + ">");
+            String[] mergedIds = entry.getMergedIds().split(",");
+            Map<String, String> uriMap = uriCreator.getUrisBasedOnIds(new HashSet<String>(Arrays.asList(mergedIds)));
+
+            for (Map.Entry<String, String> uri : uriMap.entrySet()) {
+                sb.append("<" + XMLConstants.NAMESPACE_PREFIX + ":" + XMLConstants.ID + " ");
+                sb.append(XMLConstants.CONCEPT_ID + "=\"" + uri.getKey() + "\" ");
+                sb.append(XMLConstants.CONCEPT_URI + "=\"" + uri.getValue() + "\"");
+                sb.append(">");
+                sb.append(uri.getValue());
+                sb.append("</" + XMLConstants.NAMESPACE_PREFIX + ":" + XMLConstants.ID + ">");
+            }
+
+            sb.append("</" + XMLConstants.NAMESPACE_PREFIX + ":" + XMLConstants.MERGED_IDS + ">");
         }
 
         sb.append("</" + XMLConstants.NAMESPACE_PREFIX + ":" + XMLConstants.CONCEPT_ENTRY + ">");

--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/msg/xml/XMLConstants.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/rest/msg/xml/XMLConstants.java
@@ -41,4 +41,5 @@ public interface XMLConstants {
     public final static String PAGE_NUMBER = "page_number";
     public final static String ERROR_MESSAGE = "error_message";
     public final static String ALTERNATIVE_IDS = "alternativeIds";
+    public final static String MERGED_IDS = "mergedIds";
 }


### PR DESCRIPTION
When user searches with the word net id that has been merged, the merged
concept will be displayed, Previously the wrapper of the word net was displayed but from
now the merged concept itself will be displayed.

Also the RESTFul apis will display the merged ids of the concepts.