### PR TITLE
[CCP-222] Deletion is done before merging

### DIFF
--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/core/IConceptManager.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/core/IConceptManager.java
@@ -121,8 +121,6 @@ public interface IConceptManager {
     public abstract void storeModifiedConcept(ConceptEntry entry, String userName)
             throws LuceneException, IllegalAccessException, IndexerRunningException;
 
-    public abstract void deleteConcept(String id, String userName) throws LuceneException, IndexerRunningException;
-
     /**
      * Fetches the concept wrapped entries based on the wordnet id
      * 

--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/core/IConceptManager.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/core/IConceptManager.java
@@ -169,13 +169,24 @@ public interface IConceptManager {
                     throws LuceneException, IllegalAccessException, IndexerRunningException;
 
     /**
-     * This method deletes the concept that is not a merged concept.
      * 
-     * @param id
+     * This method deletes the concept that is passed as a parameter.
+     * 
+     * @param entry
      * @param userName
      * @throws LuceneException
      * @throws IndexerRunningException
      */
-    public void deleteNonMergedConcept(String id, String userName) throws LuceneException, IndexerRunningException;
+    public void deleteConcept(ConceptEntry entry, String userName) throws LuceneException, IndexerRunningException;
+
+    /**
+     * This method fetches the local CCP concept entries. It could be a local
+     * concept entry or a wrapped concept entry. It does not fetch the merged
+     * concept entries.
+     * 
+     * @param conceptId
+     * @return
+     */
+    public ConceptEntry getLocalConceptEntry(String conceptId);
 
 }

--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/core/IConceptManager.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/core/IConceptManager.java
@@ -168,4 +168,14 @@ public interface IConceptManager {
             int page, int numberOfRecordsPerPage)
                     throws LuceneException, IllegalAccessException, IndexerRunningException;
 
+    /**
+     * This method deletes the concept that is not a merged concept.
+     * 
+     * @param id
+     * @param userName
+     * @throws LuceneException
+     * @throws IndexerRunningException
+     */
+    public void deleteNonMergedConcept(String id, String userName) throws LuceneException, IndexerRunningException;
+
 }

--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/core/impl/ConceptManager.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/core/impl/ConceptManager.java
@@ -107,6 +107,11 @@ public class ConceptManager implements IConceptManager {
         return entry;
     }
 
+    @Override
+    public ConceptEntry getLocalConceptEntry(String conceptId) {
+        return client.getEntry(conceptId);
+    }
+
     /*
      * (non-Javadoc)
      * 
@@ -524,16 +529,22 @@ public class ConceptManager implements IConceptManager {
         indexService.deleteById(concept.getId(), userName);
     }
 
-    public void deleteNonMergedConcept(String id, String userName) throws LuceneException, IndexerRunningException {
-        ConceptEntry concept = client.getEntry(id);
-        concept.setDeleted(true);
-        ChangeEvent changeEvent = new ChangeEvent();
-        changeEvent.setType(ChangeEventTypes.DELETION);
-        changeEvent.setDate(new Date());
-        changeEvent.setUserName(userName);
-        concept.addNewChangeEvent(changeEvent);
-        client.update(concept, DBNames.DICTIONARY_DB);
-        indexService.deleteById(concept.getId(), userName);
+    /**
+     * This method deletes the concept that is passed as a parameter. If the
+     * concept entry is null, then this method does nothing.
+     */
+    @Override
+    public void deleteConcept(ConceptEntry entry, String userName) throws LuceneException, IndexerRunningException {
+        if (entry != null) {
+            entry.setDeleted(true);
+            ChangeEvent changeEvent = new ChangeEvent();
+            changeEvent.setType(ChangeEventTypes.DELETION);
+            changeEvent.setDate(new Date());
+            changeEvent.setUserName(userName);
+            entry.addNewChangeEvent(changeEvent);
+            client.update(entry, DBNames.DICTIONARY_DB);
+            indexService.deleteById(entry.getId(), userName);
+        }
     }
 
     @Override

--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/core/impl/ConceptManager.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/core/impl/ConceptManager.java
@@ -524,6 +524,18 @@ public class ConceptManager implements IConceptManager {
         indexService.deleteById(concept.getId(), userName);
     }
 
+    public void deleteNonMergedConcept(String id, String userName) throws LuceneException, IndexerRunningException {
+        ConceptEntry concept = client.getEntry(id);
+        concept.setDeleted(true);
+        ChangeEvent changeEvent = new ChangeEvent();
+        changeEvent.setType(ChangeEventTypes.DELETION);
+        changeEvent.setDate(new Date());
+        changeEvent.setUserName(userName);
+        concept.addNewChangeEvent(changeEvent);
+        client.update(concept, DBNames.DICTIONARY_DB);
+        indexService.deleteById(concept.getId(), userName);
+    }
+
     @Override
     public ConceptEntry getConceptWrappedEntryByWordNetId(String wordNetID)
             throws IllegalAccessException, LuceneException, IndexerRunningException {

--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/core/impl/ConceptManager.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/core/impl/ConceptManager.java
@@ -516,34 +516,21 @@ public class ConceptManager implements IConceptManager {
         return builder.toString();
     }
 
-    @Override
-    public void deleteConcept(String id, String userName) throws LuceneException, IndexerRunningException {
-        ConceptEntry concept = getConceptEntry(id);
-        concept.setDeleted(true);
-        ChangeEvent changeEvent = new ChangeEvent();
-        changeEvent.setType(ChangeEventTypes.DELETION);
-        changeEvent.setDate(new Date());
-        changeEvent.setUserName(userName);
-        concept.addNewChangeEvent(changeEvent);
-        client.update(concept, DBNames.DICTIONARY_DB);
-        indexService.deleteById(concept.getId(), userName);
-    }
-
     /**
-     * This method deletes the concept that is passed as a parameter. If the
-     * concept entry is null, then this method does nothing.
+     * This method deletes the concept that is passed as a parameter. If a null
+     * value is passed as a concept, this method does nothing.
      */
     @Override
-    public void deleteConcept(ConceptEntry entry, String userName) throws LuceneException, IndexerRunningException {
-        if (entry != null) {
-            entry.setDeleted(true);
+    public void deleteConcept(ConceptEntry concept, String userName) throws LuceneException, IndexerRunningException {
+        if (concept != null) {
+            concept.setDeleted(true);
             ChangeEvent changeEvent = new ChangeEvent();
             changeEvent.setType(ChangeEventTypes.DELETION);
             changeEvent.setDate(new Date());
             changeEvent.setUserName(userName);
-            entry.addNewChangeEvent(changeEvent);
-            client.update(entry, DBNames.DICTIONARY_DB);
-            indexService.deleteById(entry.getId(), userName);
+            concept.addNewChangeEvent(changeEvent);
+            client.update(concept, DBNames.DICTIONARY_DB);
+            indexService.deleteById(concept.getId(), userName);
         }
     }
 

--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/service/impl/ConceptMergeService.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/service/impl/ConceptMergeService.java
@@ -135,7 +135,7 @@ public class ConceptMergeService implements IConceptMergeService {
                 // because changeevent object needs to be updated for
                 // deletion correctly.
                 String conceptWrapperId = createConceptWrapperById(id, userName, conceptsMergeBean);
-                conceptManager.deleteConcept(conceptWrapperId, userName);
+                conceptManager.deleteConcept(conceptManager.getConceptEntry(conceptWrapperId), userName);
             } else if (!id.equalsIgnoreCase(conceptsMergeBean.getSelectedConceptId().trim())) {
                 conceptManager.deleteConcept(conceptManager.getLocalConceptEntry(id), userName);
             }

--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/service/impl/ConceptMergeService.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/service/impl/ConceptMergeService.java
@@ -109,8 +109,6 @@ public class ConceptMergeService implements IConceptMergeService {
             throws LuceneException, IndexerRunningException, IllegalAccessException, DictionaryDoesNotExistException,
             DictionaryModifyException {
 
-        deleteMergedConcepts(userName, conceptsMergeBean);
-
         if (conceptsMergeBean.getSelectedConceptId().trim().equals("")) {
             // Add
             ConceptEntry entry = new ConceptEntry();
@@ -122,6 +120,8 @@ public class ConceptMergeService implements IConceptMergeService {
             fillConceptEntry(entry, conceptsMergeBean);
             conceptManager.storeModifiedConcept(entry, userName);
         }
+
+        deleteMergedConcepts(userName, conceptsMergeBean);
     }
 
     private void deleteMergedConcepts(String userName, ConceptsMergeBean conceptsMergeBean)
@@ -137,7 +137,7 @@ public class ConceptMergeService implements IConceptMergeService {
                 String conceptWrapperId = createConceptWrapperById(id, userName, conceptsMergeBean);
                 conceptManager.deleteConcept(conceptWrapperId, userName);
             } else if (!id.equalsIgnoreCase(conceptsMergeBean.getSelectedConceptId().trim())) {
-                conceptManager.deleteConcept(id, userName);
+                conceptManager.deleteNonMergedConcept(id, userName);
             }
         }
     }
@@ -145,7 +145,7 @@ public class ConceptMergeService implements IConceptMergeService {
     private String createConceptWrapperById(String wrapperId, String userName, ConceptsMergeBean conceptsMergeBean)
             throws IllegalAccessException, DictionaryDoesNotExistException, DictionaryModifyException, LuceneException,
             IndexerRunningException {
-        ConceptEntry entry = conceptManager.getConceptEntry(wrapperId);
+        ConceptEntry entry = conceptManager.getWordnetConceptEntry(wrapperId);
         // Creating concept wrapper with all the values, because in future we
         // will be including manipulations on deleted wrappers as well.
         // WrapperId has been added to delete the wordnet id. If this wordnet

--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/service/impl/ConceptMergeService.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/service/impl/ConceptMergeService.java
@@ -109,6 +109,8 @@ public class ConceptMergeService implements IConceptMergeService {
             throws LuceneException, IndexerRunningException, IllegalAccessException, DictionaryDoesNotExistException,
             DictionaryModifyException {
 
+        deleteMergedConcepts(userName, conceptsMergeBean);
+
         if (conceptsMergeBean.getSelectedConceptId().trim().equals("")) {
             // Add
             ConceptEntry entry = new ConceptEntry();
@@ -120,8 +122,6 @@ public class ConceptMergeService implements IConceptMergeService {
             fillConceptEntry(entry, conceptsMergeBean);
             conceptManager.storeModifiedConcept(entry, userName);
         }
-
-        deleteMergedConcepts(userName, conceptsMergeBean);
     }
 
     private void deleteMergedConcepts(String userName, ConceptsMergeBean conceptsMergeBean)

--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/service/impl/ConceptMergeService.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/app/service/impl/ConceptMergeService.java
@@ -137,7 +137,7 @@ public class ConceptMergeService implements IConceptMergeService {
                 String conceptWrapperId = createConceptWrapperById(id, userName, conceptsMergeBean);
                 conceptManager.deleteConcept(conceptWrapperId, userName);
             } else if (!id.equalsIgnoreCase(conceptsMergeBean.getSelectedConceptId().trim())) {
-                conceptManager.deleteNonMergedConcept(id, userName);
+                conceptManager.deleteConcept(conceptManager.getLocalConceptEntry(id), userName);
             }
         }
     }

--- a/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/web/ConceptDeleteController.java
+++ b/Conceptpower+Spring/src/main/java/edu/asu/conceptpower/web/ConceptDeleteController.java
@@ -128,7 +128,7 @@ public class ConceptDeleteController {
             return model;
         }
 
-        conceptManager.deleteConcept(id, principal.getName());
+        conceptManager.deleteConcept(conceptManager.getConceptEntry(id), principal.getName());
         if (fromHomeScreenDelete.equalsIgnoreCase("true")) {
             model.setViewName("redirect:/login");
             return model;


### PR DESCRIPTION
Deletion is done before merging, because once the concepts are merged, the change made
in the getConceptEntry in ConceptManager always fetches the merged concept. Because of
this instead of fetching the original concept and setting it to deleted, we set the delete
flag on the merged concept.